### PR TITLE
Fix out of bounds prototypeTable access

### DIFF
--- a/libs/open303-code/Source/DSPCode/rosic_MipMappedWaveTable.cpp
+++ b/libs/open303-code/Source/DSPCode/rosic_MipMappedWaveTable.cpp
@@ -66,7 +66,7 @@ void MipMappedWaveTable::setSymmetry(double newSymmetry)
 
 void MipMappedWaveTable::initPrototypeTable()
 {
-  for(int i=0; i<(tableLength+4); i++)
+  for(int i=0; i<tableLength; i++)
     prototypeTable[i] = 0.0;
 }
 


### PR DESCRIPTION
In https://github.com/baconpaul/BaconPlugs/blob/main/libs/open303-code/Source/DSPCode/rosic_MipMappedWaveTable.h#L170 we can see it declared as `double prototypeTable[tableLength];`
So make sure to respect those bounds.

The `tableLength+4` is only used for `tableSet`, not here.