### PR TITLE
Fix uninitialised values and memory leaks

### DIFF
--- a/libs/open303-code/Source/DSPCode/rosic_OnePoleFilter.cpp
+++ b/libs/open303-code/Source/DSPCode/rosic_OnePoleFilter.cpp
@@ -6,6 +6,7 @@ using namespace rosic;
 
 OnePoleFilter::OnePoleFilter()
 {
+  mode = 0;
   shelvingGain = 1.0;
   setSampleRate(44100.0);  // sampleRate = 44100 Hz by default
   setMode      (0);        // bypass by default

--- a/src/Components.hpp
+++ b/src/Components.hpp
@@ -356,6 +356,9 @@ struct NStepDraggableLEDWidget : public ParamWidget {
             Vec(0, 0), this->box.size, this,
             &NStepDraggableLEDWidget<NSteps, ColorModel>::drawSegments);
     }
+    ~NStepDraggableLEDWidget() override {
+        delete buffer;
+    }
 
     int getStep() {
         float pvalue = 0.0;
@@ -507,6 +510,9 @@ struct DotMatrixLightTextWidget
     float ledSize, padSize;
 
     DotMatrixLightTextWidget() : Widget(), buffer(NULL), currentText("") {}
+    ~DotMatrixLightTextWidget() override {
+        delete buffer;
+    }
 
     void setup() {
         ledSize = 2;
@@ -543,6 +549,7 @@ struct DotMatrixLightTextWidget
             }
             fontData[key[0]] = valmap;
         }
+        json_decref(json);
     }
 
     // create takes a function


### PR DESCRIPTION
Detected by valgrind.

Leaks are due to widgets being allocated and not added as child, so there is no auto-cleanup for them.

The uninitialised part was simply because `mode` was being read early.
Related log for that one:

```
==869036== Conditional jump or move depends on uninitialised value(s)
==869036==    at 0x236E1FA: rosic::OnePoleFilter::calcCoeffs() (rosic_OnePoleFilter.cpp:80)
==869036==    by 0x236E04F: rosic::OnePoleFilter::setSampleRate(double) (rosic_OnePoleFilter.cpp:25)
==869036==    by 0x236DFBA: rosic::OnePoleFilter::OnePoleFilter() (rosic_OnePoleFilter.cpp:10)
==869036==    by 0xEAC16B: rosic::TeeBeeFilter::TeeBeeFilter() (rosic_TeeBeeFilter.cpp:7)
==869036==    by 0xEA97FC: rosic::Open303::Open303() (rosic_Open303.cpp:7)
==869036==    by 0xE6E02E: Open303Rack::Open303Rack() (Open303.cpp:56)
==869036==    by 0xE715B7: rack::CardinalPluginModel<Open303Rack, Open303RackWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==  Uninitialised value was created by a heap allocation
==869036==    at 0x6E8E013: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0xE715AC: rack::CardinalPluginModel<Open303Rack, Open303RackWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036== 

==869036== Use of uninitialised value of size 8
==869036==    at 0x236E211: rosic::OnePoleFilter::calcCoeffs() (rosic_OnePoleFilter.cpp:80)
==869036==    by 0x236E04F: rosic::OnePoleFilter::setSampleRate(double) (rosic_OnePoleFilter.cpp:25)
==869036==    by 0x236DFBA: rosic::OnePoleFilter::OnePoleFilter() (rosic_OnePoleFilter.cpp:10)
==869036==    by 0xEAC16B: rosic::TeeBeeFilter::TeeBeeFilter() (rosic_TeeBeeFilter.cpp:7)
==869036==    by 0xEA97FC: rosic::Open303::Open303() (rosic_Open303.cpp:7)
==869036==    by 0xE6E02E: Open303Rack::Open303Rack() (Open303.cpp:56)
==869036==    by 0xE715B7: rack::CardinalPluginModel<Open303Rack, Open303RackWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==  Uninitialised value was created by a heap allocation
==869036==    at 0x6E8E013: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0xE715AC: rack::CardinalPluginModel<Open303Rack, Open303RackWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036== 

==869036== Conditional jump or move depends on uninitialised value(s)
==869036==    at 0x236E1FA: rosic::OnePoleFilter::calcCoeffs() (rosic_OnePoleFilter.cpp:80)
==869036==    by 0x236E04F: rosic::OnePoleFilter::setSampleRate(double) (rosic_OnePoleFilter.cpp:25)
==869036==    by 0x236DFBA: rosic::OnePoleFilter::OnePoleFilter() (rosic_OnePoleFilter.cpp:10)
==869036==    by 0xEA987A: rosic::Open303::Open303() (rosic_Open303.cpp:7)
==869036==    by 0xE6E02E: Open303Rack::Open303Rack() (Open303.cpp:56)
==869036==    by 0xE715B7: rack::CardinalPluginModel<Open303Rack, Open303RackWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==  Uninitialised value was created by a heap allocation
==869036==    at 0x6E8E013: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0xE715AC: rack::CardinalPluginModel<Open303Rack, Open303RackWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036== 

==869036== Use of uninitialised value of size 8
==869036==    at 0x236E211: rosic::OnePoleFilter::calcCoeffs() (rosic_OnePoleFilter.cpp:80)
==869036==    by 0x236E04F: rosic::OnePoleFilter::setSampleRate(double) (rosic_OnePoleFilter.cpp:25)
==869036==    by 0x236DFBA: rosic::OnePoleFilter::OnePoleFilter() (rosic_OnePoleFilter.cpp:10)
==869036==    by 0xEA987A: rosic::Open303::Open303() (rosic_Open303.cpp:7)
==869036==    by 0xE6E02E: Open303Rack::Open303Rack() (Open303.cpp:56)
==869036==    by 0xE715B7: rack::CardinalPluginModel<Open303Rack, Open303RackWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==  Uninitialised value was created by a heap allocation
==869036==    at 0x6E8E013: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0xE715AC: rack::CardinalPluginModel<Open303Rack, Open303RackWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036== 

==869036== Conditional jump or move depends on uninitialised value(s)
==869036==    at 0x236E1FA: rosic::OnePoleFilter::calcCoeffs() (rosic_OnePoleFilter.cpp:80)
==869036==    by 0x236E04F: rosic::OnePoleFilter::setSampleRate(double) (rosic_OnePoleFilter.cpp:25)
==869036==    by 0x236DFBA: rosic::OnePoleFilter::OnePoleFilter() (rosic_OnePoleFilter.cpp:10)
==869036==    by 0xEA988C: rosic::Open303::Open303() (rosic_Open303.cpp:7)
==869036==    by 0xE6E02E: Open303Rack::Open303Rack() (Open303.cpp:56)
==869036==    by 0xE715B7: rack::CardinalPluginModel<Open303Rack, Open303RackWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==  Uninitialised value was created by a heap allocation
==869036==    at 0x6E8E013: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0xE715AC: rack::CardinalPluginModel<Open303Rack, Open303RackWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036== 

==869036== Use of uninitialised value of size 8
==869036==    at 0x236E211: rosic::OnePoleFilter::calcCoeffs() (rosic_OnePoleFilter.cpp:80)
==869036==    by 0x236E04F: rosic::OnePoleFilter::setSampleRate(double) (rosic_OnePoleFilter.cpp:25)
==869036==    by 0x236DFBA: rosic::OnePoleFilter::OnePoleFilter() (rosic_OnePoleFilter.cpp:10)
==869036==    by 0xEA988C: rosic::Open303::Open303() (rosic_Open303.cpp:7)
==869036==    by 0xE6E02E: Open303Rack::Open303Rack() (Open303.cpp:56)
==869036==    by 0xE715B7: rack::CardinalPluginModel<Open303Rack, Open303RackWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==  Uninitialised value was created by a heap allocation
==869036==    at 0x6E8E013: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0xE715AC: rack::CardinalPluginModel<Open303Rack, Open303RackWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036== 

==869036== Conditional jump or move depends on uninitialised value(s)
==869036==    at 0x236E1FA: rosic::OnePoleFilter::calcCoeffs() (rosic_OnePoleFilter.cpp:80)
==869036==    by 0x236E04F: rosic::OnePoleFilter::setSampleRate(double) (rosic_OnePoleFilter.cpp:25)
==869036==    by 0x236DFBA: rosic::OnePoleFilter::OnePoleFilter() (rosic_OnePoleFilter.cpp:10)
==869036==    by 0xEA989E: rosic::Open303::Open303() (rosic_Open303.cpp:7)
==869036==    by 0xE6E02E: Open303Rack::Open303Rack() (Open303.cpp:56)
==869036==    by 0xE715B7: rack::CardinalPluginModel<Open303Rack, Open303RackWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==  Uninitialised value was created by a heap allocation
==869036==    at 0x6E8E013: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0xE715AC: rack::CardinalPluginModel<Open303Rack, Open303RackWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036== 

==869036== Use of uninitialised value of size 8
==869036==    at 0x236E211: rosic::OnePoleFilter::calcCoeffs() (rosic_OnePoleFilter.cpp:80)
==869036==    by 0x236E04F: rosic::OnePoleFilter::setSampleRate(double) (rosic_OnePoleFilter.cpp:25)
==869036==    by 0x236DFBA: rosic::OnePoleFilter::OnePoleFilter() (rosic_OnePoleFilter.cpp:10)
==869036==    by 0xEA989E: rosic::Open303::Open303() (rosic_Open303.cpp:7)
==869036==    by 0xE6E02E: Open303Rack::Open303Rack() (Open303.cpp:56)
==869036==    by 0xE715B7: rack::CardinalPluginModel<Open303Rack, Open303RackWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==  Uninitialised value was created by a heap allocation
==869036==    at 0x6E8E013: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0xE715AC: rack::CardinalPluginModel<Open303Rack, Open303RackWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036== 
```