### PR TITLE
Do not show theme related menu options under Cardinal

### DIFF
--- a/src/BaconModuleWidget.h
+++ b/src/BaconModuleWidget.h
@@ -24,12 +24,14 @@ struct BaconModuleWidget : rack::app::ModuleWidget, StyleParticipant
     }
 
     void appendContextMenu(ui::Menu *menu) override {
+#ifndef USING_CARDINAL_NOT_RACK
         menu->addChild(new rack::ui::MenuSeparator);
         auto st = BaconStyle::get();
         menu->addChild(rack::createMenuItem("Light Mode", CHECKMARK(st->activeStyle == BaconStyle::LIGHT),
                                             [](){BaconStyle::get()->setStyle(BaconStyle::LIGHT);}));
         menu->addChild(rack::createMenuItem("Dark Mode", CHECKMARK(st->activeStyle == BaconStyle::DARK),
                                             [](){BaconStyle::get()->setStyle(BaconStyle::DARK);}));
+#endif
         appendModuleSpecificContextMenu(menu);
     }
 


### PR DESCRIPTION
In Cardinal the light/dark mode is a global view menu option, plugin specific light/dark options are typically unwanted.
Integration for BaconMusic modules in Cardinal is done on an external file, no other changes needed on this repo.